### PR TITLE
hide tags selection on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,9 @@
               <span class="badge badge-info badge-pill">{{ city.members }}</span>
             </li>
           </ul>
+        </div>
 
+        <div class="col-sm-2 cities-group d-none d-md-block d-lg-none">
           <ul class="list-group cities-list">
             <li class="list-group-item list-group-item-inverse cities-title">Choisissez une compétence</li>
             <li class="list-group-item justify-content-between list-group-item-action city-menu"


### PR DESCRIPTION
As a workaround before putting tag selection in a dropdown, consider hiding them on mobile is a start.